### PR TITLE
Fix markdown2.markdown method call

### DIFF
--- a/olxutils/helpers.py
+++ b/olxutils/helpers.py
@@ -39,14 +39,16 @@ class OLXHelpers(object):
                 "use-file-vars"
             ]
 
-        return markdown2.markdown(content, extras)
+        return markdown2.markdown(content,
+                                  extras=extras)
 
     @classmethod
     def markdown_file(cls, filename, extras=None):
         content = ''
         with codecs.open(filename, 'r', encoding="utf-8") as f:
             content = f.read()
-        return cls.markdown(content, extras)
+        return cls.markdown(content,
+                            extras=extras)
 
     @staticmethod
     def swift_tempurl(path, date):


### PR DESCRIPTION
The method signature for markdown2.markdown is

def markdown(text, html4tags=False, tab_width=DEFAULT_TAB_WIDTH,
             safe_mode=None, extras=None, link_patterns=None,
	                  use_file_vars=False):

In other words, the second positional parameter is html4tags, not
extras, and thus calling

markdown2.markdown(content, extras)

... merely initializes html4tags with a True value (for a non-empty
list), but doesn't actually enable any extras.

Correct the call to read

markdown2.markdown(content, extras=extras)

And also fix up the other call signature for clarity.

Fixes hastexo/olx-utils#7.