### PR TITLE
Refactor the CLI, part 2

### DIFF
--- a/olxutils/__main__.py
+++ b/olxutils/__main__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 from .cli import main
 

--- a/olxutils/cli.py
+++ b/olxutils/cli.py
@@ -138,9 +138,7 @@ class CLI(object):
         )
         sys.stderr.write(message.format(self.opts.name))
 
-    def main(self, argv=sys.argv):
-        self.parse_args(argv[1:])
-
+    def new_run(self):
         if self.opts.create_branch:
             self.check_branch()
 
@@ -153,6 +151,10 @@ class CLI(object):
             self.show_branch_message()
 
         sys.stderr.write("All done!\n")
+
+    def main(self, argv=sys.argv):
+        self.parse_args(argv[1:])
+        self.new_run()
 
 
 def main(argv=sys.argv):

--- a/olxutils/cli.py
+++ b/olxutils/cli.py
@@ -35,21 +35,17 @@ class CLI(object):
                                   u"and commit them."))
         parser.add_argument('-p', "--public",
                             action="store_true",
-                            help=u"Make the course run public"
-        )
+                            help=u"Make the course run public")
         parser.add_argument('-s', "--suffix",
-                            help=u"The run name suffix"
-        )
+                            help=u"The run name suffix")
         parser.add_argument("name",
                             help=u"The run identifier")
         parser.add_argument("start_date",
                             type=valid_date,
-                            help=u"When the course run starts (YYYY-MM-DD)"
-        )
+                            help=u"When the course run starts (YYYY-MM-DD)")
         parser.add_argument("end_date",
                             type=valid_date,
-                            help=u"When the course run ends (YYYY-MM-DD)"
-        )
+                            help=u"When the course run ends (YYYY-MM-DD)")
 
         self.opts = parser.parse_args(args)
 

--- a/olxutils/cli.py
+++ b/olxutils/cli.py
@@ -3,6 +3,7 @@
 """
 New course run
 """
+from __future__ import unicode_literals
 
 import sys
 
@@ -23,65 +24,65 @@ class CLI(object):
             try:
                 return datetime.strptime(s, "%Y-%m-%d")
             except ValueError:
-                msg = u"Not a valid date: '{0}'.".format(s)
+                msg = "Not a valid date: '{0}'.".format(s)
                 raise ArgumentTypeError(msg)
 
-        parser = ArgumentParser(description=u"Create a new course run")
+        parser = ArgumentParser(description="Create a new course run")
 
         parser.add_argument('-b', "--create-branch",
                             action="store_true",
-                            help=(u"Create a new 'run/NAME' "
-                                  u"git branch, add changed files, "
-                                  u"and commit them."))
+                            help=("Create a new 'run/NAME' "
+                                  "git branch, add changed files, "
+                                  "and commit them."))
         parser.add_argument('-p', "--public",
                             action="store_true",
-                            help=u"Make the course run public")
+                            help="Make the course run public")
         parser.add_argument('-s', "--suffix",
-                            help=u"The run name suffix")
+                            help="The run name suffix")
         parser.add_argument("name",
-                            help=u"The run identifier")
+                            help="The run identifier")
         parser.add_argument("start_date",
                             type=valid_date,
-                            help=u"When the course run starts (YYYY-MM-DD)")
+                            help="When the course run starts (YYYY-MM-DD)")
         parser.add_argument("end_date",
                             type=valid_date,
-                            help=u"When the course run ends (YYYY-MM-DD)")
+                            help="When the course run ends (YYYY-MM-DD)")
 
         self.opts = parser.parse_args(args)
 
         if self.opts.name == "_base":
-            message = u"This run name is reserved.  Please choose another one."
+            message = "This run name is reserved.  Please choose another one."
             parser.error(message)
 
         if self.opts.end_date < self.opts.start_date:
-            message = (u"End date [{:%Y-%m-%d}] "
-                       u"must be greater than or equal "
-                       u"to start date [{:%Y-%m-%d}].")
+            message = ("End date [{:%Y-%m-%d}] "
+                       "must be greater than or equal "
+                       "to start date [{:%Y-%m-%d}].")
             parser.error(message.format(self.opts.end_date,
                                         self.opts.start_date))
 
     def check_branch(self):
         try:
-            check_call(u"git rev-parse --verify run/{}".format(self.opts.name),
+            check_call("git rev-parse --verify run/{}".format(self.opts.name),
                        shell=True)
         except CalledProcessError:
             pass
         else:
             message = (
-                u"The target git branch already exists.  "
-                u"Please delete it and try again.\n"
-                u"You can do so with: \n"
-                u"\n"
-                u"git branch -d run/{}\n"
+                "The target git branch already exists.  "
+                "Please delete it and try again.\n"
+                "You can do so with: \n"
+                "\n"
+                "git branch -d run/{}\n"
             )
             sys.stderr.write(message.format(self.opts.name))
             sys.exit(1)
 
         try:
-            check_call(u"git checkout -b run/{}".format(self.opts.name),
+            check_call("git checkout -b run/{}".format(self.opts.name),
                        shell=True)
         except CalledProcessError:
-            message = u"Error creating branch 'run/{}'\n"
+            message = "Error creating branch 'run/{}'\n"
             sys.stderr.write(message.format(self.opts.name))
             sys.exit(1)
 
@@ -107,33 +108,33 @@ class CLI(object):
     def create_symlinks(self):
         # Create symlink for policies
         try:
-            check_call(u"ln -sf _base policies/{}".format(self.opts.name),
+            check_call("ln -sf _base policies/{}".format(self.opts.name),
                        shell=True)
         except CalledProcessError:
-            sys.stderr.write(u"Error creating policies symlink.\n")
+            sys.stderr.write("Error creating policies symlink.\n")
             sys.exit(1)
 
     def create_branch(self):
         # Git add the changed files and commit them.
         try:
-            check_call(u"git add .",
+            check_call("git add .",
                        shell=True)
-            check_call(u"git commit -m 'New run: {}'".format(self.opts.name),
+            check_call("git commit -m 'New run: {}'".format(self.opts.name),
                        shell=True)
         except CalledProcessError:
-            sys.stderr.write(u"Error commiting new run.\n")
+            sys.stderr.write("Error commiting new run.\n")
             sys.exit(1)
 
     def show_branch_message(self):
         message = (
-            u"\n"
-            u"To push this new branch upstream, run:\n"
-            u"\n"
-            u"$ git push -u origin run/{}\n"
-            u"\n"
-            u"To switch back to master, run:\n"
-            u"\n"
-            u"$ git checkout master\n"
+            "\n"
+            "To push this new branch upstream, run:\n"
+            "\n"
+            "$ git push -u origin run/{}\n"
+            "\n"
+            "To switch back to master, run:\n"
+            "\n"
+            "$ git checkout master\n"
         )
         sys.stderr.write(message.format(self.opts.name))
 
@@ -151,7 +152,7 @@ class CLI(object):
             self.create_branch()
             self.show_branch_message()
 
-        sys.stderr.write(u"All done!\n")
+        sys.stderr.write("All done!\n")
 
 
 def main(argv=sys.argv):

--- a/olxutils/cli.py
+++ b/olxutils/cli.py
@@ -9,6 +9,8 @@ import sys
 
 import os
 
+import warnings
+
 from argparse import ArgumentParser, ArgumentTypeError
 
 from datetime import datetime
@@ -182,6 +184,9 @@ class CLI(object):
         command = argv[0]
 
         if os.path.basename(command) == 'new_run.py':
+            warnings.warn('"new_run.py" is deprecated, '
+                          'use "%s new-run" instead' % CANONICAL_COMMAND_NAME,
+                          FutureWarning)
             # Mangle the command into "olx new-run".
             argv[0] = os.path.join(os.path.dirname(command),
                                    CANONICAL_COMMAND_NAME)

--- a/olxutils/helpers.py
+++ b/olxutils/helpers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """ Custom Mako helpers """
+from __future__ import unicode_literals
 
 import textwrap
 import markdown2
@@ -16,7 +17,7 @@ class OLXHelpers(object):
     """
     @staticmethod
     def suffix(s):
-        return u' ({})'.format(s) if s else u''
+        return ' ({})'.format(s) if s else ''
 
     @staticmethod
     def date(d):
@@ -25,7 +26,7 @@ class OLXHelpers(object):
     @staticmethod
     def markdown(content, extras=None):
         # Fix up whitespace.
-        if content[0] == u"\n":
+        if content[0] == "\n":
             content = content[1:]
         content = content.rstrip()
         content = textwrap.dedent(content)
@@ -60,7 +61,7 @@ class OLXHelpers(object):
         assert(swift_path)
         assert(swift_tempurl_key)
 
-        path = u"{}{}".format(swift_path, path)
+        path = "{}{}".format(swift_path, path)
         timestamp = int(date.strftime("%s"))
         temp_url = generate_temp_url(path,
                                      timestamp,
@@ -68,4 +69,4 @@ class OLXHelpers(object):
                                      'GET',
                                      absolute=True)
 
-        return u"{}{}".format(swift_endpoint, temp_url)
+        return "{}{}".format(swift_endpoint, temp_url)

--- a/olxutils/templates.py
+++ b/olxutils/templates.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 import os
 import sys

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
+            'olx=olxutils.cli:main',
             'olx-new-run=olxutils.cli:main',
             'new_run.py=olxutils.cli:main',
         ],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-from .test_helpers import *  # noqa: F401, F403

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,7 +24,8 @@ from unittest import TestCase
 
 class OLXUtilsCLITestCase(TestCase):
     """
-    Run the CLI by importing the cli module and invoking its main() method.
+    Run the CLI by importing the cli module and invoking its main()
+    method
     """
 
     CLI_PATH = cli.__file__
@@ -48,19 +49,19 @@ class OLXUtilsCLITestCase(TestCase):
             sys.stderr = sys.__stderr__
 
     def test_invalid_name(self):
-        cmdline = '%s _base 2019-01-01 2019-01-31' % self.CLI_PATH
+        cmdline = '%s new-run _base 2019-01-01 2019-01-31' % self.CLI_PATH
         expected_output = "This run name is reserved."
         self.execute_and_check_error(cmdline,
                                      expected_output)
 
     def test_end_before_start_date(self):
-        cmdline = '%s foo 2019-02-01 2019-01-31' % self.CLI_PATH
+        cmdline = '%s new-run foo 2019-02-01 2019-01-31' % self.CLI_PATH
         expected_output = "must be greater than or equal"
         self.execute_and_check_error(cmdline,
                                      expected_output)
 
     def test_invalid_date(self):
-        cmdline = '%s foo 2019-02-01 2019-02-31' % self.CLI_PATH
+        cmdline = '%s new-run foo 2019-02-01 2019-02-31' % self.CLI_PATH
         expected_output = "Not a valid date:"
         self.execute_and_check_error(cmdline,
                                      expected_output)
@@ -69,7 +70,7 @@ class OLXUtilsCLITestCase(TestCase):
 class OLXUtilsCustomArgsTestCase(OLXUtilsCLITestCase):
     """
     Run the CLI by importing the cli module and invoking its main()
-    method, overriding its "args" argument.
+    method, overriding its "args" argument
     """
 
     def execute_and_check_error(self,
@@ -119,13 +120,39 @@ class OLXUtilsShellTestCase(OLXUtilsCLITestCase):
         self.assertIn(expected_output.encode(),
                       stderr)
 
+    def test_invalid_name(self):
+        cmdline = '%s _base 2019-01-01 2019-01-31' % self.CLI_PATH
+        expected_output = "This run name is reserved."
+        self.execute_and_check_error(cmdline,
+                                     expected_output)
 
-class MainModuleTestCase(OLXUtilsShellTestCase):
+    def test_end_before_start_date(self):
+        cmdline = '%s foo 2019-02-01 2019-01-31' % self.CLI_PATH
+        expected_output = "must be greater than or equal"
+        self.execute_and_check_error(cmdline,
+                                     expected_output)
+
+    def test_invalid_date(self):
+        cmdline = '%s foo 2019-02-01 2019-02-31' % self.CLI_PATH
+        expected_output = "Not a valid date:"
+        self.execute_and_check_error(cmdline,
+                                     expected_output)
+
+
+class OLXUtilsShellSubcommandTestCase(OLXUtilsShellTestCase):
+    """
+    Runs the CLI by invoking "olx new-run" in a subprocess, which
+    should be picked up in $PATH.
+    """
+    CLI_PATH = 'olx new-run'
+
+
+class MainModuleSubcommandTestCase(OLXUtilsShellTestCase):
     """
     Test the __main__.py module, that is, invoking Python with the -m
-    package option
+    package option (with a subcommand)
     """
-    CLI_PATH = '%s -m olxutils' % sys.executable
+    CLI_PATH = '%s -m olxutils new-run' % sys.executable
 
 
 class NewRunPyTestCase(OLXUtilsShellTestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,6 +99,26 @@ class OLXUtilsCustomArgsTestCase(OLXUtilsCLITestCase):
             sys.stderr = sys.__stderr__
 
 
+class NewRunPyCustomArgsTestCase(OLXUtilsCustomArgsTestCase):
+    """
+    Run the CLI by importing the cli module and invoking its main()
+    method, overriding its "args" argument and setting argv[0]
+    to "new_run.py"
+    """
+    CLI_PATH = 'new_run.py'
+    SUBCOMMAND = None
+
+
+class OLXNewRunCustomArgsTestCase(OLXUtilsCustomArgsTestCase):
+    """
+    Run the CLI by importing the cli module and invoking its main()
+    method, overriding its "args" argument and setting argv[0]
+    to "olx-new-run"
+    """
+    CLI_PATH = 'olx-new-run'
+    SUBCOMMAND = None
+
+
 class OLXUtilsShellTestCase(OLXUtilsCLITestCase):
     """
     Runs the CLI by invoking "olx-new-run" in a subprocess, which

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,6 +29,14 @@ class OLXUtilsCLITestCase(TestCase):
     """
 
     CLI_PATH = cli.__file__
+    SUBCOMMAND = 'new-run'
+
+    def create_command(self,
+                       argstring):
+        command = [self.CLI_PATH, argstring]
+        if self.SUBCOMMAND:
+            command.insert(1, self.SUBCOMMAND)
+        return ' '.join(command)
 
     def execute_and_check_error(self,
                                 cmdline,
@@ -49,19 +57,19 @@ class OLXUtilsCLITestCase(TestCase):
             sys.stderr = sys.__stderr__
 
     def test_invalid_name(self):
-        cmdline = '%s new-run _base 2019-01-01 2019-01-31' % self.CLI_PATH
+        cmdline = self.create_command('_base 2019-01-01 2019-01-31')
         expected_output = "This run name is reserved."
         self.execute_and_check_error(cmdline,
                                      expected_output)
 
     def test_end_before_start_date(self):
-        cmdline = '%s new-run foo 2019-02-01 2019-01-31' % self.CLI_PATH
+        cmdline = self.create_command('foo 2019-02-01 2019-01-31')
         expected_output = "must be greater than or equal"
         self.execute_and_check_error(cmdline,
                                      expected_output)
 
     def test_invalid_date(self):
-        cmdline = '%s new-run foo 2019-02-01 2019-02-31' % self.CLI_PATH
+        cmdline = self.create_command('foo 2019-02-01 2019-02-31')
         expected_output = "Not a valid date:"
         self.execute_and_check_error(cmdline,
                                      expected_output)
@@ -102,6 +110,7 @@ class OLXUtilsShellTestCase(OLXUtilsCLITestCase):
     # the system PATH, so when we subsequently invoke
     # subprocess.Popen, this should get correctly picked up.
     CLI_PATH = 'olx-new-run'
+    SUBCOMMAND = None
 
     # The tests in this class don't use check_call as its use in
     # combination with subprocess.PIPE is strongly discouraged.
@@ -120,31 +129,14 @@ class OLXUtilsShellTestCase(OLXUtilsCLITestCase):
         self.assertIn(expected_output.encode(),
                       stderr)
 
-    def test_invalid_name(self):
-        cmdline = '%s _base 2019-01-01 2019-01-31' % self.CLI_PATH
-        expected_output = "This run name is reserved."
-        self.execute_and_check_error(cmdline,
-                                     expected_output)
-
-    def test_end_before_start_date(self):
-        cmdline = '%s foo 2019-02-01 2019-01-31' % self.CLI_PATH
-        expected_output = "must be greater than or equal"
-        self.execute_and_check_error(cmdline,
-                                     expected_output)
-
-    def test_invalid_date(self):
-        cmdline = '%s foo 2019-02-01 2019-02-31' % self.CLI_PATH
-        expected_output = "Not a valid date:"
-        self.execute_and_check_error(cmdline,
-                                     expected_output)
-
 
 class OLXUtilsShellSubcommandTestCase(OLXUtilsShellTestCase):
     """
     Runs the CLI by invoking "olx new-run" in a subprocess, which
     should be picked up in $PATH.
     """
-    CLI_PATH = 'olx new-run'
+    CLI_PATH = 'olx'
+    SUBCOMMAND = 'new-run'
 
 
 class MainModuleSubcommandTestCase(OLXUtilsShellTestCase):
@@ -152,7 +144,8 @@ class MainModuleSubcommandTestCase(OLXUtilsShellTestCase):
     Test the __main__.py module, that is, invoking Python with the -m
     package option (with a subcommand)
     """
-    CLI_PATH = '%s -m olxutils new-run' % sys.executable
+    CLI_PATH = '%s -m olxutils' % sys.executable
+    SUBCOMMAND = 'new-run'
 
 
 class NewRunPyTestCase(OLXUtilsShellTestCase):
@@ -160,3 +153,4 @@ class NewRunPyTestCase(OLXUtilsShellTestCase):
     # Run the CLI tests with the deprecated compatibility alias
     """
     CLI_PATH = 'new_run.py'
+    SUBCOMMAND = None

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import os
 
 from olxutils import helpers
@@ -14,12 +16,12 @@ class OLXHelpersTestCase(TestCase):
 class SuffixTest(OLXHelpersTestCase):
 
     def test_expected_suffix(self):
-        expected = (('foo', u' (foo)'),
-                    ('spam eggs', u' (spam eggs)'),
-                    (u'', u''),
-                    ('', u''),
-                    (None, u''),
-                    (False, u''))
+        expected = (('foo', ' (foo)'),
+                    ('spam eggs', ' (spam eggs)'),
+                    ('', ''),
+                    ('', ''),
+                    (None, ''),
+                    (False, ''))
         for t in expected:
             self.assertEqual(self.h.suffix(t[0]),
                              t[1])
@@ -28,9 +30,9 @@ class SuffixTest(OLXHelpersTestCase):
 class MarkdownTest(OLXHelpersTestCase):
 
     def test_basic_markdown(self):
-        expected = (('**foo**', u'<p><strong>foo</strong></p>\n'),
-                    ('*bar*', u'<p><em>bar</em></p>\n'),
-                    ('*baz*', u'<p><em>baz</em></p>\n'))
+        expected = (('**foo**', '<p><strong>foo</strong></p>\n'),
+                    ('*bar*', '<p><em>bar</em></p>\n'),
+                    ('*baz*', '<p><em>baz</em></p>\n'))
 
         for t in expected:
             # No extras
@@ -41,10 +43,10 @@ class MarkdownTest(OLXHelpersTestCase):
                              t[1])
 
     def test_strip_whitespace(self):
-        expected = (('\n*bar*', u'<p><em>bar</em></p>\n'),
-                    ('\nspam', u'<p>spam</p>\n'),
-                    ('\n*bar*   ', u'<p><em>bar</em></p>\n'),
-                    ('\nspam    ', u'<p>spam</p>\n'))
+        expected = (('\n*bar*', '<p><em>bar</em></p>\n'),
+                    ('\nspam', '<p>spam</p>\n'),
+                    ('\n*bar*   ', '<p><em>bar</em></p>\n'),
+                    ('\nspam    ', '<p>spam</p>\n'))
 
         for t in expected:
             # No extras

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ python =
   3.6: py36,flake8
 
 [flake8]
-ignore = E124
 
 [coverage:run]
 include =


### PR DESCRIPTION
Eventually, we're going to want `olx` to do more than just create a new run. Thus, implement subcommand functionality and make a few more related changes:

* Turn `olx-new-run` into `olx new-run`, retaining the previous syntax as a compatibility alias.
* Also retain `new_run.py`, but add a user-facing FutureWarning.
* Use unicode literals everywhere.
* Improve the unit tests.
