### PR TITLE
Implement package versions based on Git tags

### DIFF
--- a/olxutils/__init__.py
+++ b/olxutils/__init__.py
@@ -1,0 +1,8 @@
+import pkg_resources
+# __version__ attribute as suggested by (deferred) PEP 396:
+# https://www.python.org/dev/peps/pep-0396/
+#
+# Single-source package definition as suggested (among several
+# options) by:
+# https://packaging.python.org/guides/single-sourcing-package-version/
+__version__ = pkg_resources.get_distribution('olx-utils').version

--- a/olxutils/cli.py
+++ b/olxutils/cli.py
@@ -16,6 +16,7 @@ from argparse import ArgumentParser, ArgumentTypeError
 from datetime import datetime
 from subprocess import check_call
 
+from olxutils import __version__
 from olxutils.templates import OLXTemplates, OLXTemplateException
 from olxutils.git import GitHelper, GitHelperException
 
@@ -40,6 +41,11 @@ class CLI(object):
 
         parser = ArgumentParser(prog=CANONICAL_COMMAND_NAME,
                                 description="Open Learning XML (OLX) utility")
+
+        parser.add_argument('-V', '--version',
+                            action='version',
+                            help="show version",
+                            version='%(prog)s ' + __version__)
 
         subparsers = parser.add_subparsers(dest='subcommand')
         new_run_help = 'Prepare a local source tree for a new course run'

--- a/requirements/setup.txt
+++ b/requirements/setup.txt
@@ -1,0 +1,2 @@
+-r base.txt
+setuptools-scm

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='olx-utils',
-    version='0.1.1',
+    use_scm_version=True,
     description='Utilities for edX OLX courses',
     long_description=open('README.rst').read(),
     url='https://github.com/hastexo/olx-utils',
@@ -50,4 +50,5 @@ setup(
         ],
     },
     package_data=package_data("olxutils", ["templates"]),
+    setup_requires=['setuptools-scm'],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ include =
 commands =
     coverage run -m unittest discover tests {posargs}
 deps =
+    -rrequirements/setup.txt
     -rrequirements/test.txt
 
 [testenv:flake8]


### PR DESCRIPTION
* Use [setuptools-scm](https://pypi.org/project/setuptools-scm/) so that `setup.py` can discern version numbers from Git tags, as recommended by option 7 in:
  https://packaging.python.org/guides/single-sourcing-package-version/
* Define a `__version__` property as recommended by (deferred) PEP 396:
  https://www.python.org/dev/peps/pep-0396/
* Add a `-V`/`--version` option to the CLI