### PR TITLE
Fix broken tests

### DIFF
--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -87,8 +87,8 @@ class GitHelperTestCase(TestCase):
                         {'PATH': ''}):
             with self.assertRaises(GitHelperException) as e:
                 self.helper.create_branch()
-                expected_msg = 'Error creating branch run/%s' % self.RUN_NAME
-                self.assertEquals(str(e), expected_msg)
+            expected_msg = 'Error creating branch run/%s' % self.RUN_NAME
+            self.assertEquals(str(e.exception), expected_msg)
 
     def test_create_branch_again(self):
         """
@@ -139,8 +139,8 @@ class GitHelperTestCase(TestCase):
                         {'PATH': ''}):
             with self.assertRaises(GitHelperException) as e:
                 self.helper.add_to_branch()
-                expected_msg = 'Error committing new run.'
-                self.assertEquals(str(e), expected_msg)
+            expected_msg = 'Error committing new run.'
+            self.assertEquals(str(e.exception), expected_msg)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)


### PR DESCRIPTION
Two invocations of `self.assertRaises()` contained both an incorrect indentation (meaning the test didn't run), and an incorrect use of the exception context (meaning the test would have failed even if the indentation had been corrected).