### PR TITLE
Fix license links in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,8 +54,9 @@ License
 -------
 
 This package is licensed under the `GNU Affero
-GPL <https://www.tldrlegal.com/l/agpl3>`__; see
-`LICENSE <LICENSE>`__ for details.
+GPL <https://tldrlegal.com/l/agpl3>`__; see
+`LICENSE <https://www.gnu.org/licenses/agpl-3.0.txt>`__
+for details.
 
 .. |PyPI version| image:: https://img.shields.io/pypi/v/olx-utils.svg
    :target: https://pypi.python.org/pypi/olx-utils


### PR DESCRIPTION
* The proper hostname for tldr;Legal is `tldrlegal.com`, not `www.tldrlegal.com`. Avoid "invalid certificate" warnings when accessing the site with HTTPS.

* While the LICENSE link correctly expands to the local file when `README.rst` is displayed on GitHub (due to some link mangling magic in the GitHub repo view), that magic does not apply when the   package's long description is displayed on PyPI. There, clicking the link generates a 404. Replace the local link with the "official" URL for the text-only version of the AGPLv3 on www.gnu.org.