### PR TITLE
Add GitLab CI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
-.coverage
+.coverage*
 .cache
 .noseids
 nosetests.xml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,53 @@
+image: python
+
+py27:
+  image: python:2.7
+  stage: build
+  script:
+    - pip install tox
+    - tox -e py27,flake8
+  artifacts:
+    paths:
+      - .coverage*
+    expire_in: 5 minutes
+
+py35:
+  image: python:3.5
+  stage: build
+  script:
+    - pip install tox
+    - tox -e py35,flake8
+  artifacts:
+    paths:
+      - .coverage*
+    expire_in: 5 minutes
+
+py36:
+  image: python:3.6
+  stage: build
+  script:
+    - pip install tox
+    - tox -e py36,flake8
+  artifacts:
+    paths:
+      - .coverage*
+    expire_in: 5 minutes
+
+py37:
+  image: python:3.7
+  stage: build
+  script:
+    - pip install tox
+    - tox -e py37,flake8
+  artifacts:
+    paths:
+      - .coverage*
+    expire_in: 5 minutes
+
+coverage:
+  stage: test
+  script:
+    - pip install coverage
+    - python -m coverage combine
+    - python -m coverage report
+  coverage: '/TOTAL.*\s+(\d+%)$/'

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ python =
 [flake8]
 
 [coverage:run]
+parallel = True
 include =
   bin/*
   olxutils/*.py


### PR DESCRIPTION
This is just an exercise in GitLab CI configuration, but it does serve two purposes:

- People who happen to mirror this repo on an internal GitLab server can use their own CI to test it.
- This reduces our reliance on Travis for integration testing.