### PR TITLE
Refactor the CLI, part 5 (plus archive subcommand)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,7 +51,7 @@ coverage:
     - python -m coverage combine
     - python -m coverage html
     - python -m coverage report
-  coverage: '/TOTAL.*\s+(\d+%)$/'
+  coverage: '/TOTAL.*\s+(\d+\.\d+%)$/'
   artifacts:
     paths:
       - htmlcov

--- a/olxutils/archive.py
+++ b/olxutils/archive.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import os
+import shutil
+import tempfile
+
+
+class ArchiveHelper(object):
+    """Helper class to facilitate the creation of course archives to be
+    imported into Open edX Studio."""
+
+    def __init__(self, root_directory, base_name, format='gztar'):
+        # The only format currently supported by Open edX Studio is
+        # gztar, i.e. a gzip-compressed tarball. If that ever changes,
+        # we can easily support others (via shutil.make_archive()).
+        self.base_name = base_name
+        self.root_directory = root_directory
+        self.format = format
+
+    def copy_files(self, destdir):
+        # We currently don't functionally distinguish between files
+        # and directories that are essential, and those that are
+        # (probably?) not.
+        directories = [
+            # apparently essential:
+            'about',
+            'chapter',
+            'html',
+            'info',
+            'policies',
+            'sequential',
+            'static',
+            # apparently not essential:
+            'assets',
+            'conditional',
+            'course',
+            'drafts',
+            'markdown',
+            'tabs',
+            'vertical',
+        ]
+        files = [
+            # apparently essential:
+            'course.xml',
+        ]
+        for d in directories:
+            source = os.path.join(self.root_directory, d)
+            if os.path.exists(source):
+                dest = os.path.join(destdir, 'course', d)
+                shutil.copytree(source, dest,
+                                symlinks=True)
+        for f in files:
+            source = os.path.join(self.root_directory, f)
+            if os.path.exists(source):
+                dest = os.path.join(destdir, 'course', f)
+                shutil.copy2(source, dest)
+
+    def make_archive(self):
+        # When dropping Python 2 support, this should be turned into
+        # using TemporaryFile as a content manager.
+        tempdir = tempfile.mkdtemp()
+        self.copy_files(destdir=tempdir)
+        filename = shutil.make_archive(self.base_name,
+                                       self.format,
+                                       root_dir=tempdir,
+                                       base_dir='course')
+        shutil.rmtree(tempdir)
+        return filename

--- a/olxutils/cli.py
+++ b/olxutils/cli.py
@@ -18,6 +18,7 @@ from datetime import datetime
 from olxutils import __version__
 from olxutils.templates import OLXTemplates, OLXTemplateException
 from olxutils.git import GitHelper, GitHelperException
+from olxutils.archive import ArchiveHelper
 
 # Under which name do we expect the CLI to be generally called?
 CANONICAL_COMMAND_NAME = 'olx'
@@ -46,30 +47,37 @@ class CLI(object):
                             help="show version",
                             version='%(prog)s ' + __version__)
 
-        new_run_help = 'Prepare a local source tree for a new course run'
-        new_run_parser = subparsers.add_parser('new-run',
-                                               help=new_run_help)
+        nr_help = 'Prepare a local source tree for a new course run'
+        nr_parser = subparsers.add_parser('new-run',
+                                          help=nr_help)
 
-        new_run_parser.add_argument('-b', "--create-branch",
-                                    action="store_true",
-                                    help=("Create a new 'run/NAME' "
-                                          "git branch, add changed files, "
-                                          "and commit them."))
-        new_run_parser.add_argument('-p', "--public",
-                                    action="store_true",
-                                    help="Make the course run public")
-        new_run_parser.add_argument('-s', "--suffix",
-                                    help="The run name suffix")
-        new_run_parser.add_argument("name",
-                                    help="The run identifier")
-        new_run_parser.add_argument("start_date",
-                                    type=valid_date,
-                                    help="When the course run starts "
-                                         "(YYYY-MM-DD)")
-        new_run_parser.add_argument("end_date",
-                                    type=valid_date,
-                                    help="When the course run ends "
-                                         "(YYYY-MM-DD)")
+        nr_parser.add_argument('-b', "--create-branch",
+                               action="store_true",
+                               help=("Create a new 'run/NAME' "
+                                     "git branch, add changed files, "
+                                     "and commit them."))
+        nr_parser.add_argument('-p', "--public",
+                               action="store_true",
+                               help="Make the course run public")
+        nr_parser.add_argument('-s', "--suffix",
+                               help="The run name suffix")
+        nr_parser.add_argument("name",
+                               help="The run identifier")
+        nr_parser.add_argument("start_date",
+                               type=valid_date,
+                               help="When the course run starts "
+                               "(YYYY-MM-DD)")
+        nr_parser.add_argument("end_date",
+                               type=valid_date,
+                               help="When the course run ends "
+                               "(YYYY-MM-DD)")
+
+        a_help = 'Create an archive for import into Open edX Studio'
+        a_parser = subparsers.add_parser('archive',
+                                         help=a_help)
+        a_parser.add_argument('-r', '--root-directory',
+                              default='.',
+                              help="Root directory of course files")
 
         self.parser = parser
 
@@ -154,6 +162,13 @@ class CLI(object):
             raise CLIException('Failed to render templates:\n' + str(t))
 
         sys.stderr.write("All done!\n")
+
+    def archive(self, root_directory='.'):
+        base_name = "archive"
+        helper = ArchiveHelper(root_directory,
+                               base_name)
+
+        helper.make_archive()
 
     def main(self, argv=sys.argv):
         """Main CLI entry point.

--- a/olxutils/cli.py
+++ b/olxutils/cli.py
@@ -77,18 +77,6 @@ class CLI(object):
 
         opts = self.parser.parse_args(args)
 
-        if opts.subcommand == 'new-run':
-            if opts.name == "_base":
-                message = ("This run name is reserved. "
-                           "Please choose another one.")
-                new_run_parser.error(message)
-            if opts.end_date < opts.start_date:
-                message = ("End date [{:%Y-%m-%d}] "
-                           "must be greater than or equal "
-                           "to start date [{:%Y-%m-%d}].")
-                new_run_parser.error(message.format(opts.end_date,
-                                                    opts.start_date))
-
         # Return the passed-in options as a dictionary
         return vars(opts)
 
@@ -123,6 +111,18 @@ class CLI(object):
                 suffix=None,
                 create_branch=False,
                 public=False):
+
+        if name == "_base":
+            message = ("This run name is reserved. "
+                       "Please choose another one.")
+            raise CLIException(message)
+        if end_date < start_date:
+            message = ("End date [{:%Y-%m-%d}] "
+                       "must be greater than or equal "
+                       "to start date [{:%Y-%m-%d}].")
+            raise CLIException(message.format(end_date,
+                                              start_date))
+
         if create_branch:
             helper = GitHelper(run=name)
 

--- a/olxutils/cli.py
+++ b/olxutils/cli.py
@@ -14,7 +14,6 @@ import warnings
 from argparse import ArgumentParser, ArgumentTypeError
 
 from datetime import datetime
-from subprocess import check_call
 
 from olxutils import __version__
 from olxutils.templates import OLXTemplates, OLXTemplateException
@@ -102,8 +101,8 @@ class CLI(object):
 
     def create_symlinks(self):
         # Create symlink for policies
-        check_call("ln -sf _base policies/{}".format(self.opts.name),
-                   shell=True)
+        os.symlink('_base',
+                   'policies/{}'.format(name))
 
     def new_run(self):
         if self.opts.create_branch:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,3 +3,4 @@ mock
 tox
 coverage
 gitpython
+invoke

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -21,3 +21,9 @@ def new_run(context,
                   to_date(start_date),
                   to_date(end_date),
                   create_branch)
+
+
+@task
+def archive(context):
+
+    CLI().archive()

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -1,0 +1,23 @@
+from __future__ import unicode_literals
+
+from datetime import datetime
+
+from invoke import task
+
+from olxutils.cli import CLI
+
+
+@task
+def new_run(context,
+            name='foo',
+            start_date='2019-01-01',
+            end_date='2019-12-31',
+            create_branch=False):
+
+    def to_date(s):
+        return datetime.strptime(s, "%Y-%m-%d")
+
+    CLI().new_run(name,
+                  to_date(start_date),
+                  to_date(end_date),
+                  create_branch)

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,9 @@ include =
   olxutils/*.py
   tests/*.py
 
+[coverage:report]
+precision = 2
+
 [testenv]
 commands =
     coverage run -m unittest discover tests {posargs}


### PR DESCRIPTION
* Replace `subprocess.check_call()` for creating a symlink with `os.symlink()`
* Re-implement subcommand functionality in a way that it can easily be called from [invoke](http://www.pyinvoke.org/)
* Move validation for course run names and dates into the `new_run()` method
* Add `archive` subcommand, which creates a gzipped tarball for upload into Open edX Studio