### PR TITLE
Make new-run fail if base branch isn't clean

### DIFF
--- a/olxutils/cli.py
+++ b/olxutils/cli.py
@@ -131,11 +131,14 @@ class CLI(object):
             raise CLIException(message.format(end_date,
                                               start_date))
 
-        if create_branch:
-            helper = GitHelper(run=name)
-
         try:
             if create_branch:
+                helper = GitHelper(run=name)
+
+                if helper.is_checkout_dirty():
+                    raise CLIException(('The local checkout is dirty, '
+                                        'please add uncommitted changes.'))
+
                 helper.create_branch()
 
             self.render_templates(name,

--- a/olxutils/git.py
+++ b/olxutils/git.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from subprocess import check_call, CalledProcessError
+from subprocess import check_output, CalledProcessError
 
 
 class GitHelperException(Exception):
@@ -17,7 +17,7 @@ class GitHelper(object):
         self.message = ""
 
     def _git_command(self, args):
-        check_call("git %s" % args, shell=True)
+        return check_output("git %s" % args, shell=True)
 
     def create_branch(self):
         if self.branch_exists():
@@ -43,6 +43,18 @@ class GitHelper(object):
             return False
 
         return True
+
+    def is_checkout_dirty(self):
+        try:
+            # "git status --porcelain" returns output if the checkout
+            # is dirty, i.e. has uncommitted or un-added changes. If
+            # the checkout is clean, it returns the empty string.
+            output = self._git_command('status --porcelain')
+            if output:
+                return True
+        except CalledProcessError:
+            raise GitHelperException('Error running git status.')
+        return False
 
     def add_to_branch(self):
         # Git add the changed files and commit them.

--- a/tests/test_full_course.py
+++ b/tests/test_full_course.py
@@ -219,6 +219,18 @@ class CLIGitFullCourseTestCase(CLIFullCourseTestCase):
         self.diff()
         self.assertIn('run/foo', self.repo.branches)
 
+    def test_render_course_matching_git_dirty(self):
+        dirtypath = os.path.join(self.sourcedir,
+                                 'dirty.txt')
+        # Pythonic "touch"
+        open(dirtypath, 'a').close()
+
+        with self.assertRaises(CLIException):
+            self.render_course("foo",
+                               "2019-01-01",
+                               "2019-12-31",
+                               True)
+
 
 class InvokeFullCourseTestCase(FullCourseTestCase):
 


### PR DESCRIPTION
This is something that has irked me for a while, so here's a PR to finally fix it:

The fact that `new-run` does and unconditional `git add .` is troublesome in that it may cause content to be included in a course run that isn't meant to be there.

Thus, if we are configured to create a new branch, check that the base branch is clean (meaning: "git status --porcelain" returns the empty string) before creating a new branch.