### PR TITLE
Improve logging and user-facing output

### DIFF
--- a/olxutils/archive.py
+++ b/olxutils/archive.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import os
+import logging
 import shutil
 import tempfile
 
@@ -17,6 +18,8 @@ class ArchiveHelper(object):
         self.base_name = base_name
         self.root_directory = root_directory
         self.format = 'gztar'
+        logging.info("Creating %s archive from %s" % (self.format,
+                                                      self.root_directory))
 
     def copy_files(self, destdir):
         # We currently don't functionally distinguish between files
@@ -47,14 +50,20 @@ class ArchiveHelper(object):
         for d in directories:
             source = os.path.join(self.root_directory, d)
             if os.path.exists(source):
+                logging.debug("Adding directory %s" % source)
                 dest = os.path.join(destdir, 'course', d)
                 shutil.copytree(source, dest,
                                 symlinks=True)
+            else:
+                logging.debug("Skipping directory %s (not found)" % source)
         for f in files:
             source = os.path.join(self.root_directory, f)
             if os.path.exists(source):
+                logging.debug("Adding file %s" % source)
                 dest = os.path.join(destdir, 'course', f)
                 shutil.copy2(source, dest)
+            else:
+                logging.debug("Skipping file %s (not found)" % source)
 
     def make_archive(self):
         # When dropping Python 2 support, this should be turned into
@@ -65,5 +74,6 @@ class ArchiveHelper(object):
                                        self.format,
                                        root_dir=tempdir,
                                        base_dir='course')
+        logging.info("Created archive: %s" % filename)
         shutil.rmtree(tempdir)
         return filename

--- a/olxutils/cli.py
+++ b/olxutils/cli.py
@@ -264,7 +264,6 @@ class CLI(object):
 
             if create_branch:
                 helper.add_to_branch()
-                logging.warn(helper.message)
 
         except CLIException:
             raise

--- a/olxutils/git.py
+++ b/olxutils/git.py
@@ -16,6 +16,7 @@ class GitHelper(object):
         self.run = run
         self.branch = self.BRANCH_FORMAT % run
         self.message = ""
+        self.old_branch = None
 
     def _git_command(self, args):
         command = "git %s" % args
@@ -30,6 +31,12 @@ class GitHelper(object):
             )
             raise GitHelperException(message.format(self.branch))
 
+        try:
+            self.old_branch = self._git_command("rev-parse --abbrev-ref HEAD")
+        except CalledProcessError:
+            # No previously existing HEAD; this is a fresh
+            # repository with no commits.
+            pass
         try:
             self._git_command("checkout -b {}".format(self.branch))
         except CalledProcessError:
@@ -67,9 +74,9 @@ class GitHelper(object):
             "\n"
             "To push this new branch upstream, run:\n"
             "\n"
-            "$ git push -u origin {}\n"
+            "$ git push -u origin {s.branch}\n"
             "\n"
-            "To switch back to master, run:\n"
+            "To switch back to {s.old_branch}, run:\n"
             "\n"
-            "$ git checkout master\n"
-        ).format(self.branch)
+            "$ git checkout {s.old_branch}\n"
+        ).format(s=self)

--- a/olxutils/git.py
+++ b/olxutils/git.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import logging
 from subprocess import check_output, CalledProcessError
 
 
@@ -17,7 +18,9 @@ class GitHelper(object):
         self.message = ""
 
     def _git_command(self, args):
-        return check_output("git %s" % args, shell=True)
+        command = "git %s" % args
+        logging.debug("+ %s" % command)
+        return check_output(command, shell=True).strip()
 
     def create_branch(self):
         if self.branch_exists():

--- a/olxutils/git.py
+++ b/olxutils/git.py
@@ -45,7 +45,7 @@ class GitHelper(object):
 
     def branch_exists(self):
         try:
-            self._git_command("rev-parse --verify {}".format(self.branch))
+            self._git_command("rev-parse -q --verify {}".format(self.branch))
         except CalledProcessError:
             return False
 

--- a/olxutils/git.py
+++ b/olxutils/git.py
@@ -15,7 +15,6 @@ class GitHelper(object):
     def __init__(self, run):
         self.run = run
         self.branch = self.BRANCH_FORMAT % run
-        self.message = ""
         self.old_branch = None
 
     def _git_command(self, args):
@@ -70,7 +69,7 @@ class GitHelper(object):
             self._git_command("commit -m 'New run: {}'".format(self.run))
         except CalledProcessError:
             raise GitHelperException('Error committing new run.')
-        self.message = (
+        message = (
             "\n"
             "To push this new branch upstream, run:\n"
             "\n"
@@ -80,3 +79,4 @@ class GitHelper(object):
             "\n"
             "$ git checkout {s.old_branch}\n"
         ).format(s=self)
+        logging.warn(message)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -55,7 +55,6 @@ class GitHelperTestCase(TestCase):
         self.assertEqual(self.helper.run, self.RUN_NAME)
         self.assertEqual(self.helper.branch,
                          'run/%s' % self.RUN_NAME)
-        self.assertFalse(self.helper.message)
 
     def test_create_branch(self):
         """
@@ -113,9 +112,6 @@ class GitHelperTestCase(TestCase):
         self.create_file('Bye bye')
         # Should add all files create since the last commit
         self.helper.add_to_branch()
-        # Should have been set to a nonempty string when
-        # the commit was successful
-        self.assertTrue(self.helper.message)
 
         # We should now have one commit on the master branch,
         # and two on the run/foo branch


### PR DESCRIPTION
A few changes primarily concerned with making `olx new-run` a bit more user-friendly in its output:

* Add some debug logging to ArchiveHelper (recording what files are being added to the archive)
* Add some debug logging to GitHelper (recording what git commands are being run)
* Suppress unhelpful git messages from user-facing output
* Stop telling people that they should switch back to master, when their run branch is not based on master
