### PR TITLE
Improved course archive support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 
 before_install:
   - pip install codecov

--- a/olxutils/archive.py
+++ b/olxutils/archive.py
@@ -39,9 +39,12 @@ class ArchiveHelper(object):
             'conditional',
             'course',
             'drafts',
+            'library_content',
             'markdown',
+            'problem',
             'tabs',
             'vertical',
+            'video',
         ]
         files = [
             # apparently essential:

--- a/olxutils/cli.py
+++ b/olxutils/cli.py
@@ -95,6 +95,9 @@ class CLI(object):
         a_parser.add_argument('-r', '--root-directory',
                               default='.',
                               help="Root directory of course files")
+        a_parser.add_argument('-b', '--base-name',
+                              default='archive',
+                              help="Name of the archive (without .tar.gz)")
 
         t_help = 'Retrieve an Open edX CMS REST API token'
         t_epilog = ('You can also set the OLX_LMS_URL, '
@@ -295,8 +298,7 @@ class CLI(object):
         loglevel = root.getEffectiveLevel() - (verbosity * 10)
         root.setLevel(loglevel)
 
-    def archive(self, root_directory='.'):
-        base_name = "archive"
+    def archive(self, root_directory='.', base_name="archive"):
         helper = ArchiveHelper(root_directory,
                                base_name)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37},flake8
+envlist = py{27,35,36,37,38},flake8
 
 [travis]
 python =
@@ -7,6 +7,7 @@ python =
   3.5: py35,flake8
   3.6: py36,flake8
   3.7: py37,flake8
+  3.8: py38,flake8
 
 [flake8]
 


### PR DESCRIPTION
* Add 3 more directories to the tarball created by `olx archive`.
* Add a `-b`/`--base-name` option to `olx archive`.
* Add Python 3.8 to the tox/travis test matrix.