### PR TITLE
Update test matrix

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,11 +10,9 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 2.7
-          - 3.5
-          - 3.6
-          - 3.7
-          - 3.8
+          - '3.8'
+          - '3.9'
+          - '3.10'
 
     steps:
     - name: Check out code

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,11 @@
 [tox]
-envlist = py{27,35,36,37,38},flake8
+envlist = py{38,39},flake8
 
 [gh-actions]
 python =
-    2.7: py27,flake8
-    3.5: py35,flake8
-    3.6: py36,flake8
-    3.7: py37,flake8
     3.8: py38,flake8
+    3.9: py39,flake8
+    3.10: py310,flake8
 
 [flake8]
 


### PR DESCRIPTION
* Drop Python 2.7 support
* Drop Python <3.8 support (we don't want to support anything older than Ubuntu Focal)
* Add support for Python 3.9 and 3.10