### PR TITLE
Support Python 3.11 and 3.12

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,6 +13,8 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
+          - '3.12'
 
     steps:
     - name: Check out code
@@ -23,10 +25,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install tox tox-gh-actions tox-pip-version 'setuptools_scm<6'
+        pip install tox tox-gh-actions setuptools_scm
     - name: Test with tox
-      env:
-        TOX_PIP_VERSION: '20.2.4'
       run: tox
     - name: Upload coverage data
       uses: actions/upload-artifact@v2

--- a/olxutils/__init__.py
+++ b/olxutils/__init__.py
@@ -1,8 +1,8 @@
-import pkg_resources
+from importlib import metadata
 # __version__ attribute as suggested by (deferred) PEP 396:
 # https://www.python.org/dev/peps/pep-0396/
 #
 # Single-source package definition as suggested (among several
 # options) by:
 # https://packaging.python.org/guides/single-sourcing-package-version/
-__version__ = pkg_resources.get_distribution('olx-utils').version
+__version__ = metadata.version('olx-utils')

--- a/olxutils/helpers.py
+++ b/olxutils/helpers.py
@@ -57,9 +57,9 @@ class OLXHelpers(object):
         swift_path = environ.get('SWIFT_PATH')
         swift_tempurl_key = environ.get('SWIFT_TEMPURL_KEY')
 
-        assert(swift_endpoint)
-        assert(swift_path)
-        assert(swift_tempurl_key)
+        assert (swift_endpoint)
+        assert (swift_path)
+        assert (swift_tempurl_key)
 
         path = "{}{}".format(swift_path, path)
         timestamp = int(date.strftime("%s"))

--- a/tests/fenced-code-blocks.html
+++ b/tests/fenced-code-blocks.html
@@ -3,14 +3,18 @@
 code.
 </code></pre>
 
-<div class="codehilite"><pre><span></span><code><span class="k">def</span> <span class="nf">this_is</span><span class="p">(</span><span class="n">some</span><span class="o">=</span><span class="s1">&#39;python&#39;</span><span class="p">):</span>
+<div class="codehilite">
+<pre><span></span><code><span class="k">def</span> <span class="nf">this_is</span><span class="p">(</span><span class="n">some</span><span class="o">=</span><span class="s1">&#39;python&#39;</span><span class="p">):</span>
     <span class="k">pass</span>
-</code></pre></div>
+</code></pre>
+</div>
 
-<div class="codehilite"><pre><span></span><code><span class="ch">#!/bin/bash</span>
+<div class="codehilite">
+<pre><span></span><code><span class="ch">#!/bin/bash</span>
 
-<span class="nb">echo</span> -n <span class="s2">&quot;Here is&quot;</span>
-cat <span class="s">&lt;&lt;EOF</span>
+<span class="nb">echo</span><span class="w"> </span>-n<span class="w"> </span><span class="s2">&quot;Here is&quot;</span>
+cat<span class="w"> </span><span class="s">&lt;&lt;EOF</span>
 <span class="s">some bash</span>
 <span class="s">EOF</span>
-</code></pre></div>
+</code></pre>
+</div>

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -64,7 +64,9 @@ class GitHelperTestCase(TestCase):
         self.add_and_commit('Test 1')
 
         self.assertFalse(self.helper.branch_exists())
-        self.assertIn('master', self.repo.branches)
+        self.assertTrue(
+            ('master' in self.repo.branches) or ('main' in self.repo.branches)
+        )
         self.helper.create_branch()
         self.assertIn('run/%s' % self.RUN_NAME,
                       self.repo.branches)
@@ -79,7 +81,9 @@ class GitHelperTestCase(TestCase):
         self.add_and_commit('Test 1')
 
         self.assertFalse(self.helper.branch_exists())
-        self.assertIn('master', self.repo.branches)
+        self.assertTrue(
+            ('master' in self.repo.branches) or ('main' in self.repo.branches)
+        )
 
         # Simulate an empty PATH, so a git command fails
         with patch.dict(os.environ,
@@ -113,11 +117,15 @@ class GitHelperTestCase(TestCase):
         # Should add all files create since the last commit
         self.helper.add_to_branch()
 
-        # We should now have one commit on the master branch,
+        # We should now have one commit on the default branch,
         # and two on the run/foo branch
-        master = self.repo.heads.master
+        default = ""
+        try:
+            default = self.repo.heads.main
+        except AttributeError:
+            default = self.repo.heads.master
         run = self.repo.heads['run/%s' % self.RUN_NAME]
-        self.assertEqual(len(master.commit.tree), 1)
+        self.assertEqual(len(default.commit.tree), 1)
         self.assertEqual(len(run.commit.tree), 2)
 
         # The commit message on the HEAD of the run/foo branch should

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -119,7 +119,7 @@ class GitHelperTestCase(TestCase):
 
         # We should now have one commit on the default branch,
         # and two on the run/foo branch
-        default = ""
+        default = None
         try:
             default = self.repo.heads.main
         except AttributeError:

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
-envlist = py{38,39},flake8
+envlist = py{38,39,310,311,312},flake8
 
 [gh-actions]
 python =
     3.8: py38,flake8
     3.9: py39,flake8
     3.10: py310,flake8
+    3.11: py311,flake8
+    3.12: py312,flake8
 
 [flake8]
 


### PR DESCRIPTION
* Replace the use of `pkg_resources` (from `setuptools`, which is no longer included in virtual environments as of 3.12) with
  `importlib.metadata`.
* Add Python 3.11 and 3.12 to the test matrix.
* Remove the obsolete use of `tox-pip-version`, and the `setuptools` version restriction, from the GitHub Actions workflow definition.